### PR TITLE
Add inner padding for weekday area in datepicker

### DIFF
--- a/guest-book.html
+++ b/guest-book.html
@@ -20,11 +20,7 @@
     <!--</div>-->
     
     
-    <div id="calendar">
-      <div class="days-week"></div>
-      <span id="now-date"></span>
-      <span id="month"></span>
-    </div>
+    <div id="calendar"></div>
     
       <script src="js/guest-book.js"></script>
     

--- a/js/guest-book.js
+++ b/js/guest-book.js
@@ -1,36 +1,41 @@
 
-let calendar = document.getElementById('calendar'),
-    nowDate = document.getElementById('now-date'),
-    month = document.getElementById('month');
+const calendar = document.getElementById('calendar');
+const now = new Date();
+const nowMonth = now.getMonth();
+const nowYear = now.getFullYear();
+const daysWeek = ['вс', 'пн', 'вт', 'ср', 'чт', 'пт', 'сб'];
 
-let now = new Date(),
-    nowMonth = now.getDay(),
-    nowYear = now.getFullYear();
-    daysWeek = ['вс', 'пн', 'вт', 'ср', 'чт', 'пт', 'сб'];
-
-function daysInMonth (month, year) {
-  return new Date(year, month, 0).getDate();
-}
-
-let quantityDays = daysInMonth(nowMonth,nowYear);
-
-function outputDays() {
-  let day = "";
-  for(let i = 1; i <= quantityDays; i++) {
-    day += "<span class='day'>" + i + "</span>";
-  }
-  return day;
+function daysInMonth(month, year) {
+  return new Date(year, month + 1, 0).getDate();
 }
 
 function outputDaysWeek() {
-  let daysWeeka = daysWeek;
+  return daysWeek
+    .map(function (dayName) {
+      return "<span class='weekday'>" + dayName + "</span>";
+    })
+    .join('');
 }
 
-console.log(daysWeeka);
+function outputDays() {
+  const quantityDays = daysInMonth(nowMonth, nowYear);
+  const firstWeekday = new Date(nowYear, nowMonth, 1).getDay();
+  let dayCells = '';
 
-let days = outputDays();
+  for (let i = 0; i < firstWeekday; i++) {
+    dayCells += "<span class='day day--empty'></span>";
+  }
 
-calendar.innerHTML = days;
+  for (let i = 1; i <= quantityDays; i++) {
+    dayCells += "<span class='day'>" + i + "</span>";
+  }
+
+  return dayCells;
+}
+
+calendar.innerHTML =
+  "<div class='days-week'>" + outputDaysWeek() + "</div>" +
+  "<div class='days-grid'>" + outputDays() + "</div>";
 
 
 

--- a/styles/general-styles.css
+++ b/styles/general-styles.css
@@ -156,12 +156,38 @@ body,
   color: #fff;
 }
 #calendar {
+  width: max-content;
+  padding: 4px 11px;
+  border: 1px solid blue;
+  border-radius: 8px;
+  background: #fff;
+}
+.days-week,
+.days-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 36px);
+  gap: 4px;
+}
+.days-week {
+  padding-bottom: 4px;
+}
+.weekday,
+.day {
+  width: 36px;
+  height: 24px;
   display: flex;
-  flex-wrap: wrap;
-  width: 140px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  font-size: 14px;
+}
+.weekday {
+  color: #666;
+  font-weight: 600;
 }
 .day {
   background: cornflowerblue;
-  width: 20px;
-  height: 20px;
+}
+.day--empty {
+  background: transparent;
 }

--- a/styles/general-styles.less
+++ b/styles/general-styles.less
@@ -38,13 +38,44 @@ body,
 }
 
 #calendar {
+  width: max-content;
+  padding: @datepicker-padding-block @datepicker-padding-inline;
+  border: 1px solid @primary;
+  border-radius: 8px;
+  background: @light;
+}
+
+.days-week,
+.days-grid {
+  display: grid;
+  grid-template-columns: repeat(7, @datepicker-cell-width);
+  gap: 4px;
+}
+
+.days-week {
+  padding-bottom: @datepicker-padding-block;
+}
+
+.weekday,
+.day {
+  width: @datepicker-cell-width;
+  height: @datepicker-cell-height;
   display: flex;
-  flex-wrap: wrap;
-  width: 140px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.weekday {
+  color: #666;
+  font-weight: 600;
 }
 
 .day {
   background: cornflowerblue;
-  width: 20px;
-  height: 20px;
+}
+
+.day--empty {
+  background: transparent;
 }

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -1,3 +1,7 @@
 @light: #fff;
 @gray: #f5f5f5;
 @primary: blue;
+@datepicker-padding-block: 4px;
+@datepicker-padding-inline: 11px;
+@datepicker-cell-width: 36px;
+@datepicker-cell-height: 24px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- render a dedicated weekday header row (`вс`-`сб`) above calendar days
- add inner datepicker padding so spacing is applied inside the weekday/day grid area
- update calendar layout to a 7-column grid with aligned weekday and day cells
- keep LESS source and compiled CSS in sync

## Validation
- `node --check js/guest-book.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddcfd5eb-83b9-499a-8f23-5e7bec5251fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddcfd5eb-83b9-499a-8f23-5e7bec5251fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

